### PR TITLE
Increase state length to 8

### DIFF
--- a/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
+++ b/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
@@ -4,7 +4,7 @@
 >   oauth2Redirect(req, res, next) {
 >     // random state
 >     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
->     const state = new Array(6).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
+>     const state = new Array(8).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
 >     req.session.oauth2State = state
 > 
 >     const redirectURI = encodeURIComponent(`${process.env.SHARELATEX_SITE_URL}/oauth/callback`) 


### PR DESCRIPTION
Authelia requires that the state must be at least be 8 characters long to ensure sufficient entropy.